### PR TITLE
feat: frames

### DIFF
--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -186,6 +186,9 @@ VALUE rb_profile_frame_singleton_method_p(VALUE frame);
  */
 VALUE rb_profile_frame_method_name(VALUE frame);
 VALUE rb_profile_frame_generation(VALUE frame);
+VALUE rb_frame_generation(VALUE frame);
+VALUE rb_frame_trace_id(VALUE frame);
+
 /**
  * Identical  to  rb_profile_frame_method_name(),  except  it  "qualifies"  the
  * return value with its defining class.

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -70,6 +70,7 @@ int rb_profile_frames(int start, int limit, VALUE *buff, int *lines);
  */
 int rb_profile_thread_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines);
 int rb_thread_frames(VALUE thread, int start, int limit, VALUE *buff);
+bool rb_set_trace_id_and_generation(int trace_id, int generation_id);
 
 /**
  * Queries the path of the passed backtrace.

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -188,6 +188,7 @@ VALUE rb_profile_frame_method_name(VALUE frame);
 VALUE rb_profile_frame_generation(VALUE frame);
 VALUE rb_frame_generation(VALUE frame);
 VALUE rb_frame_trace_id(VALUE frame);
+VALUE rb_frame_method_name(VALUE frame);
 
 /**
  * Identical  to  rb_profile_frame_method_name(),  except  it  "qualifies"  the

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -186,7 +186,6 @@ VALUE rb_profile_frame_singleton_method_p(VALUE frame);
  * @retval     otherwise  Name of the method of the frame.
  */
 VALUE rb_profile_frame_method_name(VALUE frame);
-VALUE rb_profile_frame_generation(VALUE frame);
 VALUE rb_frame_generation(VALUE frame);
 VALUE rb_frame_trace_id(VALUE frame);
 VALUE rb_frame_method_name(VALUE frame);

--- a/include/ruby/debug.h
+++ b/include/ruby/debug.h
@@ -69,6 +69,7 @@ int rb_profile_frames(int start, int limit, VALUE *buff, int *lines);
  * @post        `lines` is filled with `__LINE__` of each backtraces.
  */
 int rb_profile_thread_frames(VALUE thread, int start, int limit, VALUE *buff, int *lines);
+int rb_thread_frames(VALUE thread, int start, int limit, VALUE *buff);
 
 /**
  * Queries the path of the passed backtrace.

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1852,6 +1852,22 @@ rb_profile_frame_generation(VALUE frame)
 }
 
 VALUE
+rb_frame_generation(VALUE frame)
+{
+    const rb_control_frame_t *cf = (rb_control_frame_t *)(frame);
+
+    return INT2NUM(cf->generation);
+}
+
+VALUE
+rb_frame_trace_id(VALUE frame)
+{
+    const rb_control_frame_t *cf = (rb_control_frame_t *)(frame);
+
+    return INT2NUM(cf->trace_id);
+}
+
+VALUE
 rb_profile_frame_method_name(VALUE frame)
 {
     const rb_callable_method_entry_t *cme = cframe(frame);

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1608,7 +1608,7 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
 
         framex_t *ptr = (framex_t *)malloc(sizeof(framex_t)); // no gc here ...
         ptr->generation = cfp->generation;
-        ptr->trace_id = cfp->trace_id;
+        ptr->trace_id = ec->trace_id;
         cme = rb_vm_frame_method_entry(cfp);
 
         if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->pc != 0) {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1602,12 +1602,9 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
             continue;
         }
 
-        framex_t *const framex = NULL;
-        *framex = (const struct framex_struct) {
-            .generation = cfp->generation // GC?
-        };
-
-        buff[i] = (VALUE)framex;
+        framex_t *ptr = (framex_t *)malloc(sizeof(framex_t)); // no gc here ...
+        ptr->generation = cfp->generation;
+        buff[i] = (VALUE)ptr;
 
         cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
         i++;

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1882,20 +1882,6 @@ rb_profile_frame_singleton_method_p(VALUE frame)
     return RBOOL(klass && !NIL_P(klass) && FL_TEST(klass, FL_SINGLETON));
 }
 
-
-VALUE
-rb_profile_frame_generation(VALUE frame)
-{
-    const rb_callable_method_entry_t *cme = cframe(frame);
-    if (cme) {
-        // return INT2NUM(1022);
-        return INT2NUM(cme->def->generation);
-    }
-
-    const rb_iseq_t *iseq = frame2iseq(frame);
-    return INT2NUM(iseq->body->param.generation);
-}
-
 VALUE
 rb_frame_generation(VALUE frame)
 {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1575,6 +1575,8 @@ rb_debug_inspector_backtrace_locations(const rb_debug_inspector_t *dc)
 
 typedef struct framex_struct {
     int generation;
+    int trace_id;
+    VALUE method_name;
 } framex_t;
 
 static int
@@ -1582,6 +1584,7 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
 {
     int i;
     const rb_control_frame_t *cfp = ec->cfp, *end_cfp = RUBY_VM_END_CONTROL_FRAME(ec);
+    const rb_callable_method_entry_t *cme;
 
     // If this function is called inside a thread after thread creation, but
     // before the CFP has been created, just return 0.  This can happen when
@@ -1604,6 +1607,20 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
 
         framex_t *ptr = (framex_t *)malloc(sizeof(framex_t)); // no gc here ...
         ptr->generation = cfp->generation;
+        ptr->trace_id = cfp->trace_id;
+        if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->pc != 0) {
+            cme = rb_vm_frame_method_entry(cfp);
+            if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ) {
+                ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
+            } else {
+                ptr->method_name = rb_profile_frame_method_name((VALUE)cfp->iseq);
+            }
+        } else {
+            if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
+                 ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
+            }
+        }
+
         buff[i] = (VALUE)ptr;
 
         cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
@@ -1861,7 +1878,7 @@ rb_profile_frame_generation(VALUE frame)
 VALUE
 rb_frame_generation(VALUE frame)
 {
-    const rb_control_frame_t *cf = (rb_control_frame_t *)(frame);
+    const framex_t *cf = (framex_t *)(frame);
 
     return INT2NUM(cf->generation);
 }
@@ -1869,9 +1886,17 @@ rb_frame_generation(VALUE frame)
 VALUE
 rb_frame_trace_id(VALUE frame)
 {
-    const rb_control_frame_t *cf = (rb_control_frame_t *)(frame);
+    const framex_t *cf = (framex_t *)(frame);
 
     return INT2NUM(cf->trace_id);
+}
+
+VALUE
+rb_frame_method_name(VALUE frame)
+{
+    const framex_t *cf = (framex_t *)(frame);
+
+    return cf->method_name;
 }
 
 VALUE

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1608,8 +1608,9 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
         framex_t *ptr = (framex_t *)malloc(sizeof(framex_t)); // no gc here ...
         ptr->generation = cfp->generation;
         ptr->trace_id = cfp->trace_id;
+        cme = rb_vm_frame_method_entry(cfp);
+
         if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->pc != 0) {
-            cme = rb_vm_frame_method_entry(cfp);
             if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ) {
                 ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
             } else {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1573,6 +1573,10 @@ rb_debug_inspector_backtrace_locations(const rb_debug_inspector_t *dc)
     return dc->backtrace;
 }
 
+typedef struct framex_struct {
+    int generation;
+} framex_t;
+
 static int
 thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
 {
@@ -1598,7 +1602,13 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
             continue;
         }
 
-        buff[i] = (VALUE)cfp;
+        framex_t *const framex = NULL;
+        *framex = (const struct framex_struct) {
+            .generation = cfp->generation // GC?
+        };
+
+        buff[i] = (VALUE)framex;
+
         cfp = RUBY_VM_PREVIOUS_CONTROL_FRAME(cfp);
         i++;
     }

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1703,6 +1703,22 @@ thread_profile_frames(rb_execution_context_t *ec, int start, int limit, VALUE *b
     return i;
 }
 
+bool
+rb_set_trace_id_and_generation(int trace_id, int generation_id)
+{
+    rb_execution_context_t *ec = rb_current_execution_context(false);
+
+    // If there is no EC, we may be attempting to profile a non-Ruby thread or a
+    // M:N shared native thread which has no active Ruby thread.
+    if (!ec) {
+        return false;
+    }
+
+    ec->trace_id = trace_id;
+    ec->generation = generation_id;
+    return true;
+}
+
 int
 rb_profile_frames(int start, int limit, VALUE *buff, int *lines)
 {

--- a/vm_backtrace.c
+++ b/vm_backtrace.c
@@ -1577,6 +1577,7 @@ typedef struct framex_struct {
     int generation;
     int trace_id;
     VALUE method_name;
+    int method_type;
 } framex_t;
 
 static int
@@ -1612,13 +1613,16 @@ thread_frames(rb_execution_context_t *ec, int start, int limit, VALUE *buff)
 
         if (VM_FRAME_RUBYFRAME_P(cfp) && cfp->pc != 0) {
             if (cme && cme->def->type == VM_METHOD_TYPE_ISEQ) {
+                ptr->method_type = 1;
                 ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
             } else {
+                ptr->method_type = 1;
                 ptr->method_name = rb_profile_frame_method_name((VALUE)cfp->iseq);
             }
         } else {
             if (cme && cme->def->type == VM_METHOD_TYPE_CFUNC) {
-                 ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
+                ptr->method_type = 0;
+                ptr->method_name = rb_profile_frame_method_name((VALUE)cme);
             }
         }
 

--- a/vm_core.h
+++ b/vm_core.h
@@ -994,6 +994,7 @@ struct rb_waiting_list {
 
 struct rb_execution_context_struct {
     int generation;
+    int trace_id;
     /* execution information */
     VALUE *vm_stack;		/* must free, must mark */
     size_t vm_stack_size;       /* size in word (byte size / sizeof(VALUE)) */

--- a/vm_core.h
+++ b/vm_core.h
@@ -425,7 +425,6 @@ struct rb_iseq_constant_body {
         int post_start;
         int post_num;
         int block_start;
-        int generation;
 
         const VALUE *opt_table; /* (opt_num + 1) entries. */
         /* opt_num and opt_table:

--- a/vm_core.h
+++ b/vm_core.h
@@ -863,7 +863,6 @@ typedef struct rb_control_frame_struct {
     const VALUE *ep;        // cfp[4] / block[1]
     const void *block_code; // cfp[5] / block[2] -- iseq, ifunc, or forwarded block handler
     void *jit_return;       // cfp[6] -- return address for JIT code
-    int trace_id;            // todo: use string
     int generation;
 
 #if VM_DEBUG_BP_CHECK

--- a/vm_core.h
+++ b/vm_core.h
@@ -851,6 +851,11 @@ struct rb_block {
     enum rb_block_type type;
 };
 
+// typedef struct rb_control_frame_struct_meta {
+//     int trace_id; // todo: use string
+//     int generation;
+// } rb_control_frame_struct_meta_t;
+
 typedef struct rb_control_frame_struct {
     const VALUE *pc;        // cfp[0]
     VALUE *sp;              // cfp[1]
@@ -859,6 +864,9 @@ typedef struct rb_control_frame_struct {
     const VALUE *ep;        // cfp[4] / block[1]
     const void *block_code; // cfp[5] / block[2] -- iseq, ifunc, or forwarded block handler
     void *jit_return;       // cfp[6] -- return address for JIT code
+    int trace_id;            // todo: use string
+    int generation;
+
 #if VM_DEBUG_BP_CHECK
     VALUE *bp_check;        // cfp[7]
 #endif

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3100,7 +3100,7 @@ vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, s
     cfp->sp = argv - 1 /* recv */;
 
     cfp->generation = ec->generation;
-    cfp->trace_id = ec->generation; // todo, assign trace_id from ec
+    cfp->trace_id = ec->trace_id; // todo, assign trace_id from ec
     iseq->body->param.generation = ec->generation;
     ec->generation += 1;
 

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -386,10 +386,6 @@ vm_push_frame(rb_execution_context_t *ec,
 {
     rb_control_frame_t *const cfp = RUBY_VM_NEXT_CONTROL_FRAME(ec->cfp);
 
-    cfp->generation = ec->generation;
-    cfp->trace_id = ec->trace_id;
-    ec->generation += 1;
-
     vm_check_frame(type, specval, cref_or_me, iseq);
     VM_ASSERT(local_size >= 0);
 
@@ -418,6 +414,7 @@ vm_push_frame(rb_execution_context_t *ec,
          }
     }
 
+    ec->generation += 1;
     /* setup new frame */
     *cfp = (const struct rb_control_frame_struct) {
         .pc         = pc,
@@ -426,6 +423,7 @@ vm_push_frame(rb_execution_context_t *ec,
         .self       = self,
         .ep         = sp - 1,
         .block_code = NULL,
+        .generation = ec->generation,
 #if VM_DEBUG_BP_CHECK
         .bp_check   = sp,
 #endif

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -386,6 +386,10 @@ vm_push_frame(rb_execution_context_t *ec,
 {
     rb_control_frame_t *const cfp = RUBY_VM_NEXT_CONTROL_FRAME(ec->cfp);
 
+    cfp->generation = ec->generation;
+    cfp->trace_id = ec->trace_id;
+    ec->generation += 1;
+
     vm_check_frame(type, specval, cref_or_me, iseq);
     VM_ASSERT(local_size >= 0);
 
@@ -3098,11 +3102,6 @@ vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, s
     VALUE *argv = cfp->sp - calling->argc;
     VALUE *sp = argv + param_size;
     cfp->sp = argv - 1 /* recv */;
-
-    cfp->generation = ec->generation;
-    cfp->trace_id = ec->trace_id; // todo, assign trace_id from ec
-    iseq->body->param.generation = ec->generation;
-    ec->generation += 1;
 
     vm_push_frame(ec, iseq, VM_FRAME_MAGIC_METHOD | VM_ENV_FLAG_LOCAL, calling->recv,
                   calling->block_handler, (VALUE)me,

--- a/vm_insnhelper.c
+++ b/vm_insnhelper.c
@@ -3099,6 +3099,8 @@ vm_call_iseq_setup_normal(rb_execution_context_t *ec, rb_control_frame_t *cfp, s
     VALUE *sp = argv + param_size;
     cfp->sp = argv - 1 /* recv */;
 
+    cfp->generation = ec->generation;
+    cfp->trace_id = ec->generation; // todo, assign trace_id from ec
     iseq->body->param.generation = ec->generation;
     ec->generation += 1;
 


### PR DESCRIPTION
1. insert trace_id and generation into execution_context
2. rb_thread_frames for exposing trace_id, generation and method_name

NOTICE:

in `thread_frames` which allocates `framex_t` but no program frees it :(. I think it's ok for a POC stage.
